### PR TITLE
Rework and fix Internet Archive downloads

### DIFF
--- a/GetIABooksActivity.py
+++ b/GetIABooksActivity.py
@@ -122,21 +122,7 @@ class GetIABooksActivity(activity.Activity):
 
         self._create_controls()
 
-        if not self.powerd_running():
-            try:
-                bus = dbus.SystemBus()
-                proxy = bus.get_object('org.freedesktop.ohm',
-                               '/org/freedesktop/ohm/Keystore')
-                self.ohm_keystore = dbus.Interface(proxy,
-                                 'org.freedesktop.ohm.Keystore')
-            except dbus.DBusException, e:
-                logging.warning("Error setting OHM inhibit: %s", e)
-                self.ohm_keystore = None
-
-    def powerd_running(self):
         self.using_powerd = os.access(POWERD_INHIBIT_DIR, os.W_OK)
-        logging.error("using_powerd: %d", self.using_powerd)
-        return self.using_powerd
 
     def _inhibit_suspend(self):
         if self.using_powerd:
@@ -146,15 +132,7 @@ class GetIABooksActivity(activity.Activity):
             fd.close()
             return True
 
-        if self.ohm_keystore is not None:
-            try:
-                self.ohm_keystore.SetKey('suspend.inhibit', 1)
-                return self.ohm_keystore.GetKey('suspend.inhibit')
-            except dbus.exceptions.DBusException:
-                logging.debug("failed to inhibit suspend")
-                return False
-        else:
-            return False
+        return False
 
     def _allow_suspend(self):
         if self.using_powerd:
@@ -164,15 +142,7 @@ class GetIABooksActivity(activity.Activity):
                     + "/%u" % os.getpid()))
             return True
 
-        if self.ohm_keystore is not None:
-            try:
-                self.ohm_keystore.SetKey('suspend.inhibit', 0)
-                return self.ohm_keystore.GetKey('suspend.inhibit')
-            except dbus.exceptions.DBusException:
-                logging.error("failed to allow suspend")
-                return False
-        else:
-            return False
+        return False
 
     def _read_configuration(self, file_name='get-books.cfg'):
         logging.error('Reading configuration from file %s', file_name)

--- a/GetIABooksActivity.py
+++ b/GetIABooksActivity.py
@@ -698,8 +698,10 @@ class GetIABooksActivity(activity.Activity):
     def download_image(self,  url):
         self._inhibit_suspend()
         if self.__image_downloader is not None:
-            self.__image_downloader.stop_download()
-        self.__image_downloader = opds.ImageDownloader(self, url)
+            self.__image_downloader.stop()
+        path = os.path.join(self.get_activity_root(),
+                            'instance', 'tmp%i' % time.time())
+        self.__image_downloader = opds.ImageDownloader(url, path)
         self.__image_downloader.connect('updated', self.__image_updated_cb)
 
     def __image_updated_cb(self, downloader, file_name):

--- a/GetIABooksActivity.py
+++ b/GetIABooksActivity.py
@@ -283,7 +283,9 @@ class GetIABooksActivity(activity.Activity):
         self.enable_button(False)
         self.clear_downloaded_bytes()
         self.book_selected = False
+        self.listview.handler_block(self.selection_cb_id)
         self.listview.clear()
+        self.listview.handler_unblock(self.selection_cb_id)
         logging.error('SOURCE %s', catalog_config['source'])
         self._books_toolbar.search_entry.props.text = ''
         self.source = catalog_config['source']
@@ -498,7 +500,8 @@ class GetIABooksActivity(activity.Activity):
 
         # books listview
         self.listview = ListView(self._lang_code_handler)
-        self.listview.connect('selection-changed', self.selection_cb)
+        self.selection_cb_id = self.listview.connect('selection-changed',
+                                                     self.selection_cb)
         self.listview.set_enable_search(False)
 
         self.list_scroller = Gtk.ScrolledWindow(hadjustment=None,
@@ -607,7 +610,6 @@ class GetIABooksActivity(activity.Activity):
         return True
 
     def selection_cb(self, widget):
-        # Testing...
         selected_book = self.listview.get_selected_book()
         if self.source == 'local_books':
             if selected_book:
@@ -766,7 +768,9 @@ class GetIABooksActivity(activity.Activity):
         self.enable_button(False)
         self.clear_downloaded_bytes()
         self.book_selected = False
+        self.listview.handler_block(self.selection_cb_id)
         self.listview.clear()
+        self.listview.handler_unblock(self.selection_cb_id)
 
         if self.queryresults is not None:
             self.queryresults.cancel()

--- a/GetIABooksActivity.py
+++ b/GetIABooksActivity.py
@@ -718,19 +718,19 @@ class GetIABooksActivity(activity.Activity):
         self.__image_downloader.connect('updated', self.__image_updated_cb)
         self.__image_downloader.connect('progress', self.__image_progress_cb)
 
-    def __image_updated_cb(self, downloader, file_name):
-        if file_name is not None:
-            self.add_image(file_name)
+    def __image_updated_cb(self, downloader, path, content_type):
+        if path is not None:
+            self.add_image(path)
             self.exist_cover_image = True
-            os.remove(file_name)
+            os.remove(path)
         else:
             self.add_default_image()
         self.__image_downloader = None
         GObject.timeout_add(500, self.progressbox.hide)
         self._allow_suspend()
 
-    def __image_progress_cb(self, downloader, value):
-        self.progressbar.set_fraction(value)
+    def __image_progress_cb(self, downloader, progress):
+        self.progressbar.set_fraction(progress)
         while Gtk.events_pending():
             Gtk.main_iteration()
 
@@ -965,7 +965,7 @@ class GetIABooksActivity(activity.Activity):
         self.__book_downloader.connect('updated', self.__book_updated_cb)
         self.__book_downloader.connect('progress', self.__book_progress_cb)
 
-    def __book_updated_cb(self, downloader, path):
+    def __book_updated_cb(self, downloader, path, content_type):
         self._books_toolbar.search_entry.set_sensitive(True)
         self.listview.props.sensitive = True
         self._allow_suspend()
@@ -988,8 +988,8 @@ class GetIABooksActivity(activity.Activity):
 
         self.__file_downloader = None
 
-    def __book_progress_cb(self, downloader, value):
-        self.progressbar.set_fraction(value)
+    def __book_progress_cb(self, downloader, progress):
+        self.progressbar.set_fraction(progress)
         while Gtk.events_pending():
             Gtk.main_iteration()
 

--- a/GetIABooksActivity.py
+++ b/GetIABooksActivity.py
@@ -797,7 +797,8 @@ class GetIABooksActivity(activity.Activity):
 
     def __query_updated_cb(self, query, midway):
         self.listview.populate(self.queryresults)
-        if 'bozo_exception' in self.queryresults._feedobj:
+        if hasattr(self.queryresults, '_feedobj') and \
+           'bozo_exception' in self.queryresults._feedobj:
             # something went wrong and we have to inform about this
             bozo_exception = self.queryresults._feedobj.bozo_exception
             if isinstance(bozo_exception, urllib2.URLError):

--- a/GetIABooksActivity.py
+++ b/GetIABooksActivity.py
@@ -618,7 +618,6 @@ class GetIABooksActivity(activity.Activity):
         selected_book = self.listview.get_selected_book()
         if self.source == 'local_books':
             if selected_book:
-                self.download_url = ''
                 self.selected_book = selected_book
                 self._download.hide()
                 self.show_book_data()
@@ -628,7 +627,7 @@ class GetIABooksActivity(activity.Activity):
         else:
             self.clear_downloaded_bytes()
             if selected_book:
-                self.update_format_combo(selected_book.get_download_links())
+                self.update_format_combo(selected_book.get_types())
                 self.selected_book = selected_book
                 self._download.show()
                 self.show_book_data()
@@ -659,12 +658,6 @@ class GetIABooksActivity(activity.Activity):
                 self.selected_language = self.selected_book.get_language()
             book_data += _('Language:\t') + self.selected_language + '\n'
         book_data += _('Publisher:\t') + self.selected_publisher + '\n'
-        if self.source != 'local_books':
-            try:
-                self.download_url = self.selected_book.get_download_links()[\
-                        self.format_combo.props.value]
-            except:
-                pass
         textbuffer = self.textview.get_buffer()
         textbuffer.set_text('\n' + book_data)
         self.enable_button(True)
@@ -946,7 +939,10 @@ class GetIABooksActivity(activity.Activity):
     def get_book(self):
         self.enable_button(False)
         self.progressbox.show_all()
-        GObject.idle_add(self.download_book, self.download_url)
+        if self.source != 'local_books':
+            self.selected_book.get_download_links(self.format_combo.props.value,
+                                                  self.download_book,
+                                                  self.get_path())
 
     def download_book(self,  url):
         logging.error('DOWNLOAD BOOK %s', url)

--- a/GetIABooksActivity.py
+++ b/GetIABooksActivity.py
@@ -20,6 +20,9 @@ import os
 import logging
 import time
 
+import gi
+gi.require_version('Gtk', '3.0')
+
 from gi.repository import Gtk
 from gi.repository import Gdk
 from gi.repository import GdkPixbuf

--- a/GetIABooksActivity.py
+++ b/GetIABooksActivity.py
@@ -994,7 +994,7 @@ class GetIABooksActivity(activity.Activity):
                     self.selected_title)
 
     def set_downloaded_bytes(self, downloaded_bytes,  total):
-        fraction = float(downloaded_bytes) / float(total)
+        fraction = float(downloaded_bytes) / float(total + 1)
         self.progressbar.set_fraction(fraction)
 
     def clear_downloaded_bytes(self):

--- a/GetIABooksActivity.py
+++ b/GetIABooksActivity.py
@@ -18,7 +18,6 @@
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 import os
 import logging
-import time
 
 from pprint import pformat
 
@@ -77,6 +76,15 @@ READ_STREAM_SERVICE = 'read-activity-http'
 # directory exists if powerd is running.  create a file here,
 # named after our pid, to inhibit suspend.
 POWERD_INHIBIT_DIR = '/var/run/powerd-inhibit-suspend'
+
+
+_sequence = 0
+
+def sequence():
+    global _sequence
+
+    _sequence += 1
+    return _sequence
 
 
 class GetIABooksActivity(activity.Activity):
@@ -704,7 +712,7 @@ class GetIABooksActivity(activity.Activity):
         if self.__image_downloader is not None:
             self.__image_downloader.stop()
         path = os.path.join(self.get_activity_root(),
-                            'instance', 'tmp%i' % time.time())
+                            'instance', '%03d.tmp' % sequence())
         self.__image_downloader = opds.FileDownloader(url, path)
         self.__image_downloader.connect('updated', self.__image_updated_cb)
 
@@ -787,8 +795,8 @@ class GetIABooksActivity(activity.Activity):
                 self._books_toolbar.search_entry.grab_focus()
                 return
             if self.source == 'Internet Archive':
-                path = os.path.join(self.get_activity_root(), 'instance',
-                                    'tmp%i.csv' % time.time())
+                path = os.path.join(self.get_activity_root(),
+                                    'instance', '%03d.tmp' % sequence())
                 self.queryresults = \
                         opds.InternetArchiveQueryResult(search_text, path)
             elif self.source in _SOURCES_CONFIG:
@@ -944,7 +952,7 @@ class GetIABooksActivity(activity.Activity):
         self.listview.props.sensitive = False
         self._books_toolbar.search_entry.set_sensitive(False)
         path = os.path.join(self.get_activity_root(), 'instance',
-                            'tmp%i' % time.time())
+                            '%03d.tmp' % sequence())
         self.__book_downloader = opds.FileDownloader(url, path)
         self.__book_downloader.connect('updated', self.__book_updated_cb)
         self.__book_downloader.connect('progress', self.__book_progress_cb)

--- a/GetIABooksActivity.py
+++ b/GetIABooksActivity.py
@@ -783,11 +783,11 @@ class GetIABooksActivity(activity.Activity):
                 self._books_toolbar.search_entry.grab_focus()
                 return
             if self.source == 'Internet Archive':
+                path = os.path.join(self.get_activity_root(), 'instance',
+                                    'tmp%i.csv' % time.time())
                 self.queryresults = \
-                        opds.InternetArchiveQueryResult(search_text,
-                        query_language, self)
+                        opds.InternetArchiveQueryResult(search_text, path)
             elif self.source in _SOURCES_CONFIG:
-            #if self.source in _SOURCES_CONFIG:
                 repo_configuration = _SOURCES_CONFIG[self.source]
                 self.queryresults = opds.RemoteQueryResult(repo_configuration,
                         search_text, query_language)

--- a/GetIABooksActivity.py
+++ b/GetIABooksActivity.py
@@ -20,6 +20,8 @@ import os
 import logging
 import time
 
+from pprint import pformat
+
 import gi
 gi.require_version('Gtk', '3.0')
 
@@ -180,8 +182,8 @@ class GetIABooksActivity(activity.Activity):
 
                 _SOURCES_CONFIG[section] = repo_config
 
-        logging.error('_SOURCES %s', _SOURCES)
-        logging.error('_SOURCES_CONFIG %s', _SOURCES_CONFIG)
+        logging.error('_SOURCES %s', pformat(_SOURCES))
+        logging.error('_SOURCES_CONFIG %s', pformat(_SOURCES_CONFIG))
 
         for section in config.sections():
             if section.startswith('Catalogs'):
@@ -206,8 +208,8 @@ class GetIABooksActivity(activity.Activity):
 
         self.filter_catalogs_by_source()
 
-        logging.error('languages %s', self.languages)
-        logging.error('catalogs %s', self.catalogs)
+        logging.error('languages %s', pformat(self.languages))
+        logging.error('catalogs %s', pformat(self.catalogs))
 
     def _add_search_controls(self, toolbar):
         book_search_item = Gtk.ToolItem()

--- a/GetIABooksActivity.py
+++ b/GetIABooksActivity.py
@@ -703,7 +703,7 @@ class GetIABooksActivity(activity.Activity):
             self.__image_downloader.stop()
         path = os.path.join(self.get_activity_root(),
                             'instance', 'tmp%i' % time.time())
-        self.__image_downloader = opds.ImageDownloader(url, path)
+        self.__image_downloader = opds.FileDownloader(url, path)
         self.__image_downloader.connect('updated', self.__image_updated_cb)
 
     def __image_updated_cb(self, downloader, file_name):

--- a/opds.py
+++ b/opds.py
@@ -231,6 +231,7 @@ class QueryResult(GObject.GObject):
                 uri += '&lang=' + self._language
 
         d_thread = DownloadThread(uri, headers, self.__feedobj_cb)
+        d_thread.daemon = True
         self.threads.append(d_thread)
         d_thread.start()
 
@@ -523,6 +524,7 @@ class InternetArchiveQueryResult(QueryResult):
                                                  self.__updated_cb,
                                                  self.__append_cb,
                                                  self.__ready_cb)
+        d_thread.daemon = True
         self.threads.append(d_thread)
         d_thread.start()
 
@@ -602,6 +604,7 @@ class FileDownloader(GObject.GObject):
 
         d_thread = FileDownloaderThread(url, path, self.__updated_cb,
                                         self.__progress_cb)
+        d_thread.daemon = True
         self.threads.append(d_thread)
         d_thread.start()
 

--- a/opds.py
+++ b/opds.py
@@ -83,7 +83,7 @@ class DownloadThread(threading.Thread):
 
         logging.debug('feedparser version %s', feedparser.__version__)
         if not self.obj.is_local() and self.midway == False:
-            uri = self.obj._uri + self.obj._queryterm.replace(' ', '+')
+            uri = self.obj._uri + self.obj._query.replace(' ', '+')
             headers = {}
             if self.obj._language is not None and self.obj._language != 'all':
                 headers['Accept-Language'] = self.obj._language
@@ -242,11 +242,11 @@ class QueryResult(GObject.GObject):
                           ([bool])),
     }
 
-    def __init__(self, configuration, queryterm, language):
+    def __init__(self, configuration, query, language):
         GObject.GObject.__init__(self)
         self._configuration = configuration
         self._uri = self._configuration['query_uri']
-        self._queryterm = queryterm
+        self._query = query
         self._language = language
         self._feedobj = None
         self._next_uri = ''
@@ -333,30 +333,30 @@ class QueryResult(GObject.GObject):
 
 class LocalVolumeQueryResult(QueryResult):
 
-    def __init__(self, path, queryterm, language):
+    def __init__(self, path, query, language):
         configuration = {'query_uri': os.path.join(path, 'catalog.xml')}
-        QueryResult.__init__(self, configuration, queryterm, language)
+        QueryResult.__init__(self, configuration, query, language)
 
     def is_local(self):
         return True
 
     def get_book_list(self):
         ret = []
-        if self._queryterm is None or self._queryterm is '':
+        if self._query is None or self._query is '':
             for entry in self._feedobj['entries']:
                 ret.append(Book(entry, basepath=os.path.dirname(self._uri)))
         else:
             for entry in self._feedobj['entries']:
                 book = Book(entry, basepath=os.path.dirname(self._uri))
-                if book.match(self._queryterm.replace(' ', '+')):
+                if book.match(self._query.replace(' ', '+')):
                     ret.append(book)
         return ret
 
 
 class RemoteQueryResult(QueryResult):
 
-    def __init__(self, configuration, queryterm, language):
-        QueryResult.__init__(self, configuration, queryterm, language)
+    def __init__(self, configuration, query, language):
+        QueryResult.__init__(self, configuration, query, language)
 
 
 class InternetArchiveBook(Book):

--- a/opds.py
+++ b/opds.py
@@ -384,7 +384,7 @@ class DownloadIAThread(threading.Thread):
         # search_tuple = queryterm.lower().split()
         FL = urllib.quote('fl[]')
         SORT = urllib.quote('sort[]')
-        self.search_url = 'http://www.archive.org/advancedsearch.php?q=' +  \
+        self.search_url = 'http://archive.org/advancedsearch.php?q=' +  \
             urllib.quote('(title:(' + self.obj._queryterm.lower() + ') OR ' + \
             'creator:(' + queryterm.lower() + ')) AND format:(DJVU)')
         self.search_url += '&' + FL + '=creator&' + FL + '=description&' + \
@@ -455,7 +455,7 @@ class DownloadIAThread(threading.Thread):
                 entry['title'] = row[6] + 'Volume ' + volume
 
             entry['links'] = {}
-            url_base = 'http://www.archive.org/download/' + \
+            url_base = 'http://archive.org/download/' + \
                         row[3] + '/' + row[3]
 
             if entry['format'].find('DjVu') > -1:
@@ -467,7 +467,7 @@ class DownloadIAThread(threading.Thread):
                 entry['links']['application/pdf'] = url_base + '_text.pdf'
             if entry['format'].find('EPUB') > -1:
                 entry['links']['application/epub+zip'] = url_base + '.epub'
-            entry['cover_image'] = 'http://www.archive.org/download/' + \
+            entry['cover_image'] = 'http://archive.org/download/' + \
                         row[3] + '/page/cover_thumb.jpg'
 
             self.obj._booklist.append(IABook(None, entry, ''))

--- a/opds.py
+++ b/opds.py
@@ -516,7 +516,7 @@ class FileDownloaderThread(threading.Thread):
             self._getter.start(self._path)
         except:
             _logger.debug("Connection timed out for")
-            self._updated_cb(None)
+            self._updated_cb(None, None)
 
         self._download_content_length = \
                 self._getter.get_content_length()
@@ -526,7 +526,7 @@ class FileDownloaderThread(threading.Thread):
         _logger.error("Got file %s (%s)", path, suggested_name)
         self._getter = None
         if not self.stopthread.is_set():
-            self._updated_cb(path)
+            self._updated_cb(path, self._download_content_type)
 
     def __progress_cb(self, getter, bytes_downloaded):
         if self.stopthread.is_set():
@@ -550,7 +550,7 @@ class FileDownloaderThread(threading.Thread):
         self._download_content_length = 0
         self._download_content_type = None
         self._getter = None
-        self._updated_cb(None)
+        self._updated_cb(None, None)
 
     def stop(self):
         self.stopthread.set()
@@ -561,7 +561,7 @@ class FileDownloader(GObject.GObject):
     __gsignals__ = {
         'updated': (GObject.SignalFlags.RUN_FIRST,
                           None,
-                          ([GObject.TYPE_STRING])),
+                          ([GObject.TYPE_STRING, GObject.TYPE_STRING])),
         'progress': (GObject.SignalFlags.RUN_FIRST,
                           None,
                           ([GObject.TYPE_FLOAT])),
@@ -577,11 +577,11 @@ class FileDownloader(GObject.GObject):
         self.threads.append(d_thread)
         d_thread.start()
 
-    def __updated_cb(self, path):
-        self.emit('updated', path)
+    def __updated_cb(self, path, content_type):
+        self.emit('updated', path, content_type)
 
-    def __progress_cb(self, value):
-        self.emit('progress', value)
+    def __progress_cb(self, progress):
+        self.emit('progress', progress)
 
     def stop(self):
         for thread in self.threads:

--- a/opds.py
+++ b/opds.py
@@ -359,7 +359,7 @@ class RemoteQueryResult(QueryResult):
         QueryResult.__init__(self, configuration, queryterm, language)
 
 
-class IABook(Book):
+class InternetArchiveBook(Book):
 
     def __init__(self, configuration, entry, basepath=None):
         Book.__init__(self, configuration, entry, basepath=None)
@@ -371,7 +371,7 @@ class IABook(Book):
         return {'jpg': self._entry['cover_image']}
 
 
-class DownloadIAThread(threading.Thread):
+class InternetArchiveDownloadThread(threading.Thread):
 
     def __init__(self, obj, midway):
         threading.Thread.__init__(self)
@@ -470,7 +470,7 @@ class DownloadIAThread(threading.Thread):
             entry['cover_image'] = 'http://archive.org/download/' + \
                         row[3] + '/page/cover_thumb.jpg'
 
-            self.obj._booklist.append(IABook(None, entry, ''))
+            self.obj._booklist.append(InternetArchiveBook(None, entry, ''))
 
         os.remove(tempfile)
         GObject.idle_add(self.obj.notify_updated, self.midway)
@@ -505,7 +505,7 @@ class InternetArchiveQueryResult(QueryResult):
         self.emit('updated', midway)
 
     def _start_download(self, midway=False):
-        d_thread = DownloadIAThread(self, midway)
+        d_thread = InternetArchiveDownloadThread(self, midway)
         self.threads.append(d_thread)
         d_thread.start()
 

--- a/opds.py
+++ b/opds.py
@@ -32,7 +32,7 @@ import sys
 sys.path.insert(0, './')
 import feedparser
 
-_logger = logging.getLogger('get-ia-books-activity')
+_logger = logging.getLogger()
 
 _REL_OPDS_ACQUISTION = u'http://opds-spec.org/acquisition'
 _REL_SUBSECTION = 'subsection'


### PR DESCRIPTION
Get Books v16 does fail to download most books on the Internet Archive because of how archive.org has shifted files around.  The old method was to guess the file name based on the identifier.  The new method is to download %{identifier}_files.xml and locate the file name in the XML.

Also took the opportunity to fix several other issues.  Have also raised a support ticket (14997) with feedbooks.com about their PDF downloads not working always, and returning zero length HTTP.  Workaround is to use EPUB format.

See the individual patches for details of change, but the summary from my NEWS file is;

* Fix warnings,
* Remove OHM,
* Fix divide by zero during download,
* Fix exception during search,
* Use archive.org not www.archive.org (faster search and download),
* Rewrite to avoid private objects and use arguments,
* Format log object dumps,
* Use file downloader for covers, books, and file lists,
* Avoid downloading all covers on list view clear (faster collection switching),
* Fix non-unique download files (fix for sometimes wrong cover shown),
* Show progress bar on cover art download,
* Fix failing downloads from Internet Archive,
* Improve download cancel,
* Destroy download threads on activity stop (otherwise stop is deferred),
* Move progress bar below Get Book button to avoid frequent book list resize.

Tested on Fedora 18 and Ubuntu 16.04.  Will be included in v16.1 at OLPC.

(Also of interest is that Ubuntu 16.04 fails to open DjVu inside Evince inside Read activity due to gnome.org 754467.  Workaround is to use PDF or EPUB format.)
