### PR TITLE
Add option to ignore mimetypes to config file

### DIFF
--- a/get-books.cfg
+++ b/get-books.cfg
@@ -8,6 +8,7 @@ query_uri = http://www.feedbooks.com/books/search.atom?query=
 opds_cover = http://opds-spec.org/image
 summary_field = summary
 blacklist = Erotica,Romance
+ignore_mimetypes = application/pdf
 
 [Catalogs_Feedbooks]
 Science Fiction = http://www.feedbooks.com/books/top.atom?category=FBFIC028000&range=week


### PR DESCRIPTION
PDF downloads (default option) in Feedbooks don't work.
Pdf option is still available in the feed, but according to Feedbooks
it will be deactivated.

So it defaults to EPUBs which do work.