### PR TITLE
Fixing no internet connection exception

### DIFF
--- a/GetIABooksActivity.py
+++ b/GetIABooksActivity.py
@@ -831,11 +831,11 @@ class GetIABooksActivity(activity.Activity):
             # something went wrong and we have to inform about this
             bozo_exception = self.queryresults._feedobj.bozo_exception
             if isinstance(bozo_exception, urllib2.URLError):
-                if isinstance(bozo_exception.reason, socket.gaierror):
-                    if bozo_exception.reason.errno == -2:
+                if isinstance(bozo_exception.reason, socket.error):
+                    if bozo_exception.reason.errno == 101:
                         self.show_message(_('Could not reach the server. '
                             'Maybe you are not connected to the network'))
-                        self.window.set_cursor(None)
+                        self.get_window().set_cursor(None)
                         return
             self.show_message(_('There was an error downloading the list.'))
         elif (len(self.queryresults.get_catalog_list()) > 0):


### PR DESCRIPTION
When the activity is not connected to internet no alert message was shown,
although there is an exception handling function implemented in the code,
named "__query_updated_cb" but it had some errors.

"bozo_exception.reason" need not to be an instance of gai(get address info) error
always so changing socket.gaierror to socket.error and also adding 101 as the
bozo_exception.reason.errno.

Fixes https://github.com/sugarlabs/get-books-activity/issues/28